### PR TITLE
Bug 1242877 - taskcluster-npm-cache supports using newer taskcluster-client for buildURL API

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "taskcluster-npm-cache",
-  "version": "1.3.1",
+  "version": "1.3.2",
   "description": "Utilities to cache package.json + npm payloads via taskcluster.",
   "main": "index.js",
   "scripts": {
@@ -39,7 +39,7 @@
     "promise": "^7.0.4",
     "promised-temp": "^0.1.0",
     "slugid": "^1.0.3",
-    "taskcluster-client": "^0.23.2"
+    "taskcluster-client": "^0.23.8"
   },
   "devDependencies": {
     "mocha": "^2.0.1",

--- a/src/bin/taskcluster-npm-cache-get.js
+++ b/src/bin/taskcluster-npm-cache-get.js
@@ -87,7 +87,8 @@ async function main() {
   let url = await queue.buildUrl(
     queue.getLatestArtifact,
     indexedTask.taskId,
-    'public/node_modules.tar.gz'
+    'public',
+    'node_modules.tar.gz'
   );
 
   let workspace = await npm(args.target);


### PR DESCRIPTION
Please see [bug 1242877](https://bugzilla.mozilla.org/show_bug.cgi?id=1242877).
