### PR TITLE
Bug 1242877 - Rename the downloaded file to node_modules.tar.gz; r=aus

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "taskcluster-npm-cache",
-  "version": "1.3.2",
+  "version": "1.3.3",
   "description": "Utilities to cache package.json + npm payloads via taskcluster.",
   "main": "index.js",
   "scripts": {

--- a/src/bin/taskcluster-npm-cache-get.js
+++ b/src/bin/taskcluster-npm-cache-get.js
@@ -87,8 +87,7 @@ async function main() {
   let url = await queue.buildUrl(
     queue.getLatestArtifact,
     indexedTask.taskId,
-    'public',
-    'node_modules.tar.gz'
+    'public/node_modules.tar.gz'
   );
 
   let workspace = await npm(args.target);

--- a/src/npm.js
+++ b/src/npm.js
@@ -35,6 +35,7 @@ class Workspace {
     let req = download().
       get(url).
       dest(target).
+      rename('node_modules.tar.gz').
       use(downloadStatus())
 
     await denodeify(req.run).call(req);


### PR DESCRIPTION
Separating the parameter (9305605e389) doesn't work because the
getLatestArtifact() takes only two arguments. We still need to use
`public/node_modules.tar.gz` for artifact name. Due to buildUrl() formalizes
the name to `public%2Fnode_modules.tar.gz`, we have to rename the downloaded
file to `node_modules.tar.gz` in order to make it can be extracted correctly.

Please see [bug 1242877](https://bugzilla.mozilla.org/show_bug.cgi?id=1242877).
